### PR TITLE
Fix progress bar "sticking", and fix "shallow" not defined (destructuring) on route 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@approximant/next-progress",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@approximant/next-progress",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@types/nprogress": "^0.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@approximant/next-progress",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@approximant/next-progress",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "@types/nprogress": "^0.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@approximant/next-progress",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@approximant/next-progress",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
         "@types/nprogress": "^0.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@approximant/next-progress",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@approximant/next-progress",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "MIT",
       "dependencies": {
         "@types/nprogress": "^0.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@sqrlplanner/nextjs-progressbar",
+  "name": "@approximant/next-progress",
   "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@sqrlplanner/nextjs-progressbar",
+      "name": "@approximant/next-progress",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@approximant/next-progress",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@approximant/next-progress",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "MIT",
       "dependencies": {
         "@types/nprogress": "^0.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@approximant/next-progress",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@approximant/next-progress",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@types/nprogress": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@approximant/next-progress",
+  "name": "@audiu/next-progress",
   "version": "0.1.0",
   "description": "NProgress component for Next.js app.",
   "main": "dist/index.js",
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/approximant/next-progress.git"
+    "url": "git+https://github.com/audiu/next-progress.git"
   },
   "keywords": [
     "Nprogress",
@@ -24,7 +24,8 @@
   "author": "Eamon Ma",
   "contributors": [
     "Eamon Ma",
-    "Apal Shah"
+    "Apal Shah",
+    "Mike Goodfellow"
   ],
   "license": "MIT",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@audiu/next-progress",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "NProgress component for Next.js app.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@audiu/next-progress",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "NProgress component for Next.js app.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@audiu/next-progress",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "NProgress component for Next.js app.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@audiu/next-progress",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "NProgress component for Next.js app.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@audiu/next-progress",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "NProgress component for Next.js app.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@audiu/next-progress",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "NProgress component for Next.js app.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -76,7 +76,6 @@ const NextProgress = ({
 }: NextProgressProps) => {
   let timer: NodeJS.Timeout | null = null;
   let debounceTimer: NodeJS.Timeout | null = null;
-  let isStarted = false;
 
   React.useEffect(() => {
     if (options) {
@@ -102,28 +101,33 @@ const NextProgress = ({
       clearTimeout(debounceTimer);
     }
 
+    console.log('routeChangeStart', _);
+
     debounceTimer = setTimeout(() => {
-      isStarted = true;
       NProgress.set(startPosition);
       NProgress.start();
+
+      console.log('routeChangeStart: debounce fired', _);
     }, debounce);
   };
 
   const routeChangeEnd = (
-    _: string,
-    cfg: RouteProps
+    _: string
   ) => {
-    if (debounceTimer && !isStarted) {
+    if (debounceTimer) {
       clearTimeout(debounceTimer);
-      return;
     }
 
-    if (cfg?.shallow && !showOnShallow) return;
+    if (timer) {
+      clearTimeout(timer);
+    }
 
-    if (timer) clearTimeout(timer);
+    console.log('routeChangeEnd', _);
+
     timer = setTimeout(() => {
-      isStarted = false;
       NProgress.done(true);
+
+      console.log('routeChangeEnd: stop fired', _);
     }, stopDelayMs);
   };
 
@@ -131,15 +135,20 @@ const NextProgress = ({
     _err: Error,
     _url: string
   ) => {
-    if (debounceTimer && !isStarted) {
+    if (debounceTimer) {
       clearTimeout(debounceTimer);
-      return;
     }
 
-    if (timer) clearTimeout(timer);
+    if (timer) {
+      clearTimeout(timer);
+    }
+
+    console.log('routeChangeError', _err, _url);
+
     timer = setTimeout(() => {
-      isStarted = false;
       NProgress.done(true);
+
+      console.log('routeChangeError: stop fired', _err, _url);
     }, stopDelayMs);
   };
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -101,13 +101,10 @@ const NextProgress = ({
       clearTimeout(debounceTimer);
     }
 
-    console.log('routeChangeStart', _);
-
     debounceTimer = setTimeout(() => {
       NProgress.set(startPosition);
       NProgress.start();
 
-      console.log('routeChangeStart: debounce fired', _);
     }, debounce);
   };
 
@@ -122,13 +119,9 @@ const NextProgress = ({
       clearTimeout(timer);
     }
 
-    console.log('routeChangeEnd', _);
-
     timer = setTimeout(() => {
-      NProgress.done(true);
-
-      console.log('routeChangeEnd: stop fired', _);
-    }, stopDelayMs);
+      NProgress.done();
+      }, stopDelayMs);
   };
 
   const routeChangeError = (
@@ -143,13 +136,9 @@ const NextProgress = ({
       clearTimeout(timer);
     }
 
-    console.log('routeChangeError', _err, _url);
-
     timer = setTimeout(() => {
-      NProgress.done(true);
-
-      console.log('routeChangeError: stop fired', _err, _url);
-    }, stopDelayMs);
+      NProgress.done();
+      }, stopDelayMs);
   };
 
   return transformCSS(`

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,10 @@ import * as NProgress from 'nprogress';
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
 
+interface RouteProps {
+  shallow: boolean;
+}
+
 export interface NextProgressProps {
   /**
    * The color of the bar.
@@ -90,13 +94,9 @@ const NextProgress = ({
 
   const routeChangeStart = (
     _: string,
-    {
-      shallow,
-    }: {
-      shallow: boolean;
-    }
+    cfg: RouteProps
   ) => {
-    if (shallow && !showOnShallow) return;
+    if (cfg?.shallow && !showOnShallow) return;
 
     if (debounceTimer) {
       clearTimeout(debounceTimer);
@@ -110,19 +110,12 @@ const NextProgress = ({
   };
 
   const routeChangeEnd = (
-    _: string,
-    {
-      shallow,
-    }: {
-      shallow: boolean;
-    }
+    _: string
   ) => {
     if (debounceTimer && !isStarted) {
       clearTimeout(debounceTimer);
       return;
     }
-
-    if (shallow && !showOnShallow) return;
 
     if (timer) clearTimeout(timer);
     timer = setTimeout(() => {
@@ -133,19 +126,12 @@ const NextProgress = ({
 
   const routeChangeError = (
     _err: Error,
-    _url: string,
-    {
-      shallow,
-    }: {
-      shallow: boolean;
-    }
+    _url: string
   ) => {
     if (debounceTimer && !isStarted) {
       clearTimeout(debounceTimer);
       return;
     }
-
-    if (shallow && !showOnShallow) return;
 
     if (timer) clearTimeout(timer);
     timer = setTimeout(() => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -76,7 +76,6 @@ const NextProgress = ({
 }: NextProgressProps) => {
   let timer: NodeJS.Timeout | null = null;
   let debounceTimer: NodeJS.Timeout | null = null;
-  let isStarted = false;
 
   React.useEffect(() => {
     if (options) {
@@ -103,7 +102,6 @@ const NextProgress = ({
     }
 
     debounceTimer = setTimeout(() => {
-      isStarted = true;
       NProgress.set(startPosition);
       NProgress.start();
     }, debounce);
@@ -112,14 +110,15 @@ const NextProgress = ({
   const routeChangeEnd = (
     _: string
   ) => {
-    if (debounceTimer && !isStarted) {
+    if (debounceTimer) {
       clearTimeout(debounceTimer);
-      return;
     }
 
-    if (timer) clearTimeout(timer);
+    if (timer) {
+      clearTimeout(timer);
+    }
+
     timer = setTimeout(() => {
-      isStarted = false;
       NProgress.done(true);
     }, stopDelayMs);
   };
@@ -128,14 +127,15 @@ const NextProgress = ({
     _err: Error,
     _url: string
   ) => {
-    if (debounceTimer && !isStarted) {
+    if (debounceTimer) {
       clearTimeout(debounceTimer);
-      return;
     }
 
-    if (timer) clearTimeout(timer);
+    if (timer) {
+      clearTimeout(timer);
+    }
+
     timer = setTimeout(() => {
-      isStarted = false;
       NProgress.done(true);
     }, stopDelayMs);
   };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -76,6 +76,7 @@ const NextProgress = ({
 }: NextProgressProps) => {
   let timer: NodeJS.Timeout | null = null;
   let debounceTimer: NodeJS.Timeout | null = null;
+  let isStarted = false;
 
   React.useEffect(() => {
     if (options) {
@@ -102,6 +103,7 @@ const NextProgress = ({
     }
 
     debounceTimer = setTimeout(() => {
+      isStarted = true;
       NProgress.set(startPosition);
       NProgress.start();
     }, debounce);
@@ -110,8 +112,9 @@ const NextProgress = ({
   const routeChangeEnd = (
     _: string
   ) => {
-    if (debounceTimer) {
+    if (debounceTimer && !isStarted) {
       clearTimeout(debounceTimer);
+      return;
     }
 
     if (timer) {
@@ -119,6 +122,7 @@ const NextProgress = ({
     }
 
     timer = setTimeout(() => {
+      isStarted = false;
       NProgress.done(true);
     }, stopDelayMs);
   };
@@ -127,8 +131,9 @@ const NextProgress = ({
     _err: Error,
     _url: string
   ) => {
-    if (debounceTimer) {
+    if (debounceTimer && !isStarted) {
       clearTimeout(debounceTimer);
+      return;
     }
 
     if (timer) {
@@ -136,6 +141,7 @@ const NextProgress = ({
     }
 
     timer = setTimeout(() => {
+      isStarted = false;
       NProgress.done(true);
     }, stopDelayMs);
   };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -110,17 +110,17 @@ const NextProgress = ({
   };
 
   const routeChangeEnd = (
-    _: string
+    _: string,
+    cfg: RouteProps
   ) => {
     if (debounceTimer && !isStarted) {
       clearTimeout(debounceTimer);
       return;
     }
 
-    if (timer) {
-      clearTimeout(timer);
-    }
+    if (cfg?.shallow && !showOnShallow) return;
 
+    if (timer) clearTimeout(timer);
     timer = setTimeout(() => {
       isStarted = false;
       NProgress.done(true);
@@ -136,10 +136,7 @@ const NextProgress = ({
       return;
     }
 
-    if (timer) {
-      clearTimeout(timer);
-    }
-
+    if (timer) clearTimeout(timer);
     timer = setTimeout(() => {
       isStarted = false;
       NProgress.done(true);


### PR DESCRIPTION
Resolved issue where double progress bar/stuck progress bar (dont force finished as this causes the progress bar to show even if it wasn't running before)

When a route change is cancelled via an example call such as `router.events.emit('routeChangeError');`, we can't destructure the obj as its not passed. It could be passed, but actually when cancelling the progress bar we don't care if it was shallow or not. Only when starting it